### PR TITLE
aligning 'high score' text in centre

### DIFF
--- a/highscore.css
+++ b/highscore.css
@@ -9,9 +9,14 @@
     margin-bottom: 0.5rem;
   }
   
+
+  
+
   .high-score:hover {
     transform: scale(1.025);
   }
   #finalScore{
    font-size: 10vw;
+   text-align: center; 
+   width: max-content;
   }


### PR DESCRIPTION
<img width="960" alt="Screenshot 2024-01-01 143630" src="https://github.com/SnowScriptWinterOfCode/QuickQuiz/assets/132822853/77f8d990-ba35-4f36-b03d-1ad0c5dfdea6">
issue #6 